### PR TITLE
Configure JReleaser for assembling and releasing

### DIFF
--- a/.github/workflows/graalvm-snapshot.yml
+++ b/.github/workflows/graalvm-snapshot.yml
@@ -1,11 +1,9 @@
 name: GraalVM Snapshot
 on:
   push:
-    tags-ignore:
-      - '*'
-    branches:
-      - '*'
+    branches: [ master ]
   pull_request:
+
 jobs:
   build:
     name: 'Build with Graal on ${{ matrix.os }}'
@@ -24,6 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/cache@v2
         with:
           path: |
@@ -32,30 +31,38 @@ jobs:
             ~/.m2/repository
           key: ${{ runner.os }}-gradle-test-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle-test-
+
       - name: 'Add Developer Command Prompt for Microsoft Visual C++ '
         if: ${{ runner.os == 'Windows' }}
         uses: ilammy/msvc-dev-cmd@v1
+
       - name: Setup GraalVM CE
         uses: DeLaGuardo/setup-graalvm@3.1
         with:
           graalvm-version: 21.2.0.java11
+
       - name: Install Native Image
         run: ${{ matrix.gu-binary }} install native-image
+
       - name: Build Native Image Snapshot
+        env:
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./gradlew :guide:html2text
           ./gradlew :pierrot:buildLayers --no-daemon
           ./gradlew :pierrot:shadowJar --no-daemon
-          native-image --no-fallback -H:ConfigurationFileDirectories=apps/pierrot/build/docker/layers/resources -cp apps/pierrot/build/libs/pierrot-*-all.jar -H:Class=com.agorapulse.pierrot.cli.PierrotCommand -H:Name=pierrot --trace-object-instantiation=java.io.FileDescriptor
+          ./gradlew :jreleaserAssemble --no-daemon
+
       - name: Verify Binary
         if: ${{ runner.os == 'Linux' || runner.os == 'macOS'}}
         env:
           GITHUB_TOKEN: ${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
           GITHUB_ORG: agorapulse
         run: |
-          ./pierrot search repo:agorapulse/pierrot filename:.testfile
-          ./pierrot status repo:agorapulse/pierrot author:musketyr
-          ./pierrot init -b chore/testbranch -t "Test Title" -m "Test Message" --project "Test Project" --workspace testws
+          CMD_BASEDIR=./build/jreleaser/assemble/pierrot/native-image
+          ${CMD_BASEDIR}/pierrot search repo:agorapulse/pierrot filename:.testfile
+          ${CMD_BASEDIR}/pierrot status repo:agorapulse/pierrot author:musketyr
+          ${CMD_BASEDIR}/pierrot init -b chore/testbranch -t "Test Title" -m "Test Message" --project "Test Project" --workspace testws
           cd testws
           cat pierrot.yml
           grep -q branch pierrot.yml
@@ -64,47 +71,48 @@ jobs:
           grep -q message pierrot.yml
           grep -q project pierrot.yml
           cd ..
-          ./pierrot push --workspace testws
-      - name: Windows Archive
-        if: ${{ runner.os == 'Windows' }}
-        run: |
-          New-Item "./pierrot-win-amd64/bin" -ItemType Directory -ea 0
-          Move-Item -Path ./pierrot.exe -Destination "./pierrot-win-amd64/bin"
-          Copy-Item "./LICENSE" -Destination "./pierrot-win-amd64"
-          Copy-Item "./docs/guide/build/html2text/README" -Destination "./pierrot-win-amd64/README"
-          Compress-Archive -Path "./pierrot-win-amd64" -Update -DestinationPath ./pierrot-win-amd64.zip
-      - name: macOS Archive
-        if: ${{ runner.os == 'macOS' }}
-        run: |
-          mkdir -p pierrot-darwin-amd64/bin
-          mv ./pierrot pierrot-darwin-amd64/bin
-          cp ./LICENSE pierrot-darwin-amd64/
-          cp ./docs/guide/build/html2text/README pierrot-darwin-amd64/README
-          zip -r pierrot-darwin-amd64.zip ./pierrot-darwin-amd64 -x '*.DS_Store*' -x '__MAC_OSX'
-      - name: Linux Archive
-        if: ${{ runner.os == 'Linux' }}
-        run: |
-          mkdir -p pierrot-linux-amd64/bin
-          mv ./pierrot pierrot-linux-amd64/bin
-          cp ./LICENSE pierrot-linux-amd64/
-          cp ./docs/guide/build/html2text/README pierrot-linux-amd64/README
-          zip -r pierrot-linux-amd64.zip ./pierrot-linux-amd64
-      - uses: actions/upload-artifact@v2
+          ${CMD_BASEDIR}/pierrot push --workspace testws
+
+      - name: 'Upload build artifact'
+        uses: actions/upload-artifact@v2
         with:
-          name: pierrot-${{ matrix.os }}.zip
-          path: pierrot-*.zip
-      - name: Docker login (master and Linux only)
-        if: github.ref == 'refs/heads/master' && runner.os == 'Linux'
-        uses: docker/login-action@v1
+          name: artifacts
+          path: |
+            apps/pierrot/build/jreleaser/assemble/pierrot/native-image/*.zip
+
+  # Collect all executables and release
+  release:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@v2
         with:
-          registry: ${{ secrets.DOCKER_REGISTRY_URL }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Build And Push Docker Image Snapshot (master and Linux only)
-        if: github.ref == 'refs/heads/master' && runner.os == 'Linux'
+          fetch-depth: 0
+
+      - name: 'Download all build artifacts'
+        uses: actions/download-artifact@v2
+
+      - name: 'Set up Java'
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: 'zulu'
+
+      - name: 'Cache Maven packages'
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.m2/repository
+          key: ${{ runner.os }}-gradle-test-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle-test-
+
+      - name: 'Release with JReleaser'
         env:
-          DOCKER_REPOSITORY_PATH: ${{ secrets.DOCKER_REPOSITORY_PATH }}
-          DOCKER_REGISTRY_URL: ${{ secrets.DOCKER_REGISTRY_URL }}
-        run: |
-          export DOCKER_IMAGE=`echo "${DOCKER_REGISTRY_URL}/${DOCKER_REPOSITORY_PATH}/pierrot" | sed -e 's#//#/#' -e 's#^/##'`
-          ./gradlew :pierrot:dockerPushNative --no-daemon
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JRELEASER_DOCKER_DEFAULT_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          JRELEASER_DOCKER_DEFAULT_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: ./gradlew -PartifactsDir=artifacts :jreleaserFullRelease

--- a/apps/pierrot/pierrot.gradle
+++ b/apps/pierrot/pierrot.gradle
@@ -15,10 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-plugins {
-    id 'io.sdkman.vendors' version '3.0.0'
-}
-
 micronaut {
     testRuntime('spock2')
     processing {
@@ -52,30 +48,3 @@ dependencies {
 application {
     mainClass.set('com.agorapulse.pierrot.cli.PierrotCommand')
 }
-
-dockerBuild {
-    images = ["${System.env.DOCKER_IMAGE ?: project.name}:$project.version"]
-}
-
-dockerBuildNative {
-    images = [
-        "${System.env.DOCKER_IMAGE ?: project.name}:$project.version",
-        "${System.env.DOCKER_IMAGE ?: project.name}:latest",
-    ]
-}
-
-dockerfileNative {
-    baseImage('gcr.io/distroless/cc-debian10')
-}
-
-sdkman {
-    candidate = 'pierrot'
-    version =  project.version
-    platforms = [
-        MAC_OSX: "https://github.com/agorapulse/pierrot/releases/download/${project.version}/pierrot-darwin-amd64-v${project.version}.zip",
-        WINDOWS_64: "https://github.com/agorapulse/pierrot/releases/download/${project.version}/pierrot-windows-amd64-v${project.version}.zip",
-        LINUX_64: "https://github.com/agorapulse/pierrot/releases/download/${project.version}/pierrot-linux-amd64-v${project.version}.zip",
-    ]
-    hashtag = 'PierrotCLI'
-}
-

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ plugins {
     id 'org.kordamp.gradle.codenarc'
     id 'org.kordamp.gradle.coveralls'
     id 'io.github.gradle-nexus.publish-plugin'
+    id 'org.jreleaser'
+    id 'com.google.osdetector'
 }
 
 if (!project.hasProperty('ossrhUsername'))      ext.ossrhUsername       = System.getenv('SONATYPE_USERNAME') ?: '**UNDEFINED**'
@@ -33,9 +35,10 @@ config {
     release = (rootProject.findProperty('release') ?: false).toBoolean()
 
     info {
-        name        = 'Pierrot'
-        vendor      = 'Agorapulse'
-        description = 'Pierrot - Multi-repository GitHub Governance Tool'
+        name          = 'Pierrot'
+        vendor        = 'Agorapulse'
+        description   = 'Pierrot - Multi-repository GitHub Governance Tool'
+        inceptionYear = '2021'
 
         links {
             website      = 'https://github.com/' + slug
@@ -205,3 +208,75 @@ gradleProjects {
 
 
 check.dependsOn('aggregateCheckstyle', 'aggregateCodenarc', 'aggregateAllTestReports', 'coveralls')
+
+jreleaser {
+    dryrun = (rootProject.findProperty('jreleaser.dryrun') ?: false).toBoolean()
+
+    environment {
+        properties.put('artifactsDir', 'build/jreleaser/assemble/pierrot/native-image')
+    }
+
+    release {
+        github {
+            branch = 'master'
+            overwrite = true
+            tagName = '{{projectVersion}}'
+            skipTag = true
+            changelog {
+                formatted = 'ALWAYS'
+                format = '- {{commitShortHash}} {{commitTitle}}'
+                contributors {
+                    format = '- {{contributorName}}'
+                }
+            }
+        }
+    }
+
+    assemble {
+        nativeImage {
+            pierrot {
+                active = 'ALWAYS'
+                 args = ['--no-fallback',
+                    '-H:ConfigurationFileDirectories=apps/pierrot/build/docker/layers/resources',
+                    '-H:Class=com.agorapulse.pierrot.cli.PierrotCommand',
+                    '--trace-object-instantiation=java.io.FileDescriptor']
+                mainJar {
+                    path = 'apps/pierrot/build/libs/{{distributionName}}-{{projectVersion}}-all.jar'
+                }
+                files {
+                    pattern = 'LICENSE'
+                }
+            }
+        }
+    }
+
+    distributions {
+        pierrot {
+            distributionType = 'NATIVE_IMAGE'
+            artifact {
+                path = '{{artifactsDir}}/{{distributionName}}-{{projectVersion}}-osx-x86_64.zip'
+                platform = 'osx-x86_64'
+            }
+            artifact {
+                path = '{{artifactsDir}}/{{distributionName}}-{{projectVersion}}-linux-x86_64.zip'
+                platform = 'linux-x86_64'
+            }
+            artifact {
+                path = '{{artifactsDir}}/{{distributionName}}-{{projectVersion}}-windows-x86_64.zip'
+                platform = 'windows-x86_64'
+            }
+            docker {
+                active = 'ALWAYS'
+                baseImage = 'gcr.io/distroless/cc-debian10'
+                imageNames = [
+                  '{{repoOwner}}/{{distributionName}}:{{tagName}}',
+                  '{{repoOwner}}/{{distributionName}}:latest'
+                ]
+                repository {
+                    owner = 'agorapulse'
+                    name = 'pierrot-docker'
+                }
+            }
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,9 +19,11 @@
 slug=agorapulse/pierrot
 group=com.agorapulse
 version=1.0.0-SNAPSHOT
+jreleaserPluginVersion=0.9.1
 kordampPluginVersion=0.47.0
 gitPublishPluginVersion=2.1.3
 nexusPluginVersion=1.0.0
+osdetectorPluginVersion=1.7.0
 
 groovyVersion=3.0.9
 spockVersion=2.0-groovy-3.0

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,11 +17,9 @@
  */
 buildscript {
     repositories {
+        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
     }
     dependencies {
         classpath group: 'org.kordamp.gradle',                      name: 'settings-gradle-plugin',         version: kordampPluginVersion
@@ -34,6 +32,8 @@ buildscript {
         classpath group: 'io.github.gradle-nexus',                  name: 'publish-plugin',                 version: nexusPluginVersion
         classpath group: 'io.micronaut.gradle',                     name: 'micronaut-gradle-plugin',        version: micronautPluginVersion
         classpath group: 'gradle.plugin.com.github.johnrengelman',  name: 'shadow',                         version: shadowPluginVersion
+        classpath group: 'org.jreleaser',                           name: 'jreleaser-gradle-plugin',        version: jreleaserPluginVersion
+        classpath group: 'gradle.plugin.com.google.gradle',         name: 'osdetector-gradle-plugin',       version: osdetectorPluginVersion
     }
 }
 

--- a/src/jreleaser/distributions/pierrot/docker/Dockerfile.tpl
+++ b/src/jreleaser/distributions/pierrot/docker/Dockerfile.tpl
@@ -1,0 +1,19 @@
+FROM {{dockerBaseImage}}
+
+{{#dockerLabels}}
+LABEL {{.}}
+{{/dockerLabels}}
+
+{{#dockerPreCommands}}
+{{.}}
+{{/dockerPreCommands}}
+
+COPY assembly/ /
+
+{{#dockerPostCommands}}
+{{.}}
+{{/dockerPostCommands}}
+
+ENV PATH="${PATH}:/{{distributionArtifactName}}/bin"
+
+ENTRYPOINT ["/{{distributionArtifactName}}/bin/{{distributionExecutable}}"]


### PR DESCRIPTION
Native executables are now generated via JReleaser.

To give it a try locally

```
$ ./gradlew :pierrot:build
$ ./gradlew :jreleaserAssemble
```

Inspect current configuration

```
$ ./gradlew :jreleaserConfig --select-current-platform
```

Perform a release in dryrun mode

```
$ ./gradlew :jreleaserRelease --select-current-platform -Pjreleaser.dryrun=true
```

Inspect
- build/jreleaser/out.properties
- build/jreleaser/trace.log
- build/jreleaser/release/CHANGELOG.md